### PR TITLE
[0.1.3] - 2026-04-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
 
+## [0.1.3] - 2026-04-22
+### Security
+- pyproject.toml: Bumped `black` to `^26.3.1` to resolve GHSA (arbitrary file writes from unsanitized user input in cache file name).
+- pyproject.toml: Bumped `pytest` to `^9.0.3` to resolve GHSA (vulnerable tmpdir handling).
+
+
 ## [0.1.2] - 2024-09-25
 ### Fixed
 - Somewhere along the line the file permissions got jacked up. Removed executable permissions off the files.

--- a/{{cookiecutter.project_directory}}/pyproject.toml
+++ b/{{cookiecutter.project_directory}}/pyproject.toml
@@ -10,13 +10,13 @@ aaron-common-libs = {git = "https://github.com/aaronmelton/aaron-common-libs.git
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.8"
-black = "^24.4.2"
+black = "^26.3.1"
 coverage = "^7.6.0"
 flake8 = "^7.1.0"
 isort = "^5.13.2"
 pydocstyle = "^6.3.0"
 pylint = "^3.2.6"
-pytest = "^8.3.1"
+pytest = "^9.0.3"
 pytest-env = "^1.1.3"
 toml = "^0.10.2"
 Flake8-pyproject = "^1.2.3"


### PR DESCRIPTION
## [0.1.3] - 2026-04-22
### Security
- pyproject.toml: Bumped `black` to `^26.3.1` to resolve GHSA (arbitrary file writes from unsanitized user input in cache file name).
- pyproject.toml: Bumped `pytest` to `^9.0.3` to resolve GHSA (vulnerable tmpdir handling).
